### PR TITLE
Enable build logic gradle cache

### DIFF
--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -1,0 +1,4 @@
+# Gradle properties are not passed to included builds https://github.com/gradle/gradle/issues/2534
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true


### PR DESCRIPTION
Enable build logic cache to help reduce subsequent builds after changes in the convention plugins.

 - [Organizing Build Logic](https://docs.gradle.org/current/userguide/organizing_gradle_projects.html#declare_properties_in_gradle_properties_file)